### PR TITLE
Removed the underline from the 'translation' button

### DIFF
--- a/vendor/nodebb-theme-harmony-2.1.35/scss/topic.scss
+++ b/vendor/nodebb-theme-harmony-2.1.35/scss/topic.scss
@@ -147,3 +147,11 @@ body.template-topic {
 		}
 	}
 }
+
+.view-translated-btn {
+	text-decoration: none !important;
+
+	&:hover {
+		text-decoration: none !important;
+	}
+}


### PR DESCRIPTION
Very simple PR to update "view translated message" button styling to match other buttons in the NodeBB UI. Previously, when not hovered over, the button's text would have an underline. Removing this feature improves design coherence, as other buttons in NodeBB do not do this.